### PR TITLE
chore: harden Renovate release age policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-required"
 }


### PR DESCRIPTION
Adds Renovate minimumReleaseAge safeguards to reduce exposure to newly published malicious packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enforce a minimum age requirement of 7 days for releases before they can be selected for updates, with timestamp validation enabled.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikhilbadyal/nikhilbadyal.github.io/pull/51)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->